### PR TITLE
Keep reading from initial file descriptor

### DIFF
--- a/lib/finalizer.js
+++ b/lib/finalizer.js
@@ -14,10 +14,10 @@ function readPath(path, size) {
         var textBuffer = new Buffer(size);
         binaryBuffer.copy(textBuffer, 0, 0, bytesRead);
         fs.readSync(fd, textBuffer, bytesRead, remainingBytes);
-        text = textBuffer.toString("utf8");
+        text = textBuffer.toString();
       }
       else {
-        text = binaryBuffer.toString("utf8");
+        text = binaryBuffer.toString();
       }
     }
     return text;


### PR DESCRIPTION
This seems to shave around 100ms from the `nak-search` benchmark for me.

I'm curious if it does the same for you.
