### PR TITLE
Include only the number of bytes read in the string

### DIFF
--- a/lib/finalizer.js
+++ b/lib/finalizer.js
@@ -13,11 +13,11 @@ function readPath(path, size) {
       if (remainingBytes > 0) {
         var textBuffer = new Buffer(size);
         binaryBuffer.copy(textBuffer, 0, 0, bytesRead);
-        fs.readSync(fd, textBuffer, bytesRead, remainingBytes);
-        text = textBuffer.toString();
+        bytesRead += fs.readSync(fd, textBuffer, bytesRead, remainingBytes);
+        text = textBuffer.toString("utf8", 0, bytesRead);
       }
       else {
-        text = binaryBuffer.toString();
+        text = binaryBuffer.toString("utf8", 0, bytesRead);
       }
     }
     return text;


### PR DESCRIPTION
After learning more about node buffers I realized this is required so that only the bytes read are included in the string.
