### PR TITLE
Test ignored patterns again relative paths

### DIFF
--- a/lib/ignorer.js
+++ b/lib/ignorer.js
@@ -33,10 +33,10 @@ Ignorer.prototype.isFileIgnored = function(filepath) {
   return false;
 };
 
-Ignorer.prototype.isDirIgnored = function(name, filepath) {
+Ignorer.prototype.isDirIgnored = function(filepath) {
   var r = this.ignoresLength;
   while (r--) {
-    if (this.ignores[r].match(name, filepath))
+    if (this.ignores[r].match(filepath))
       return true;
   }
   return false;

--- a/lib/walkdir.js
+++ b/lib/walkdir.js
@@ -72,7 +72,7 @@ walker.walkdir = function(fpath, options, printCb, done) {
   },
 
   readdir = function(filepath) {
-    if (!ignorer.isDirIgnored(path.basename(filepath), filepath)) {
+    if (!ignorer.isDirIgnored(path.relative(fpath, filepath))) {
       job(1);
       // async doesn't matter, we sort results at end anyway
       fs.readdir(filepath, function(err, files) {
@@ -88,7 +88,7 @@ walker.walkdir = function(fpath, options, printCb, done) {
     var fileCount = files.length, prefix = filepath + DIR_SEP;
     while (fileCount--) {
       var file = files.shift(), filename = prefix + file;
-      if (!ignorer.isFileIgnored(filename)) {
+      if (!ignorer.isFileIgnored(path.relative(fpath, filename))) {
         statter(filepath, filename);
       }
     }
@@ -99,7 +99,7 @@ walker.walkdir = function(fpath, options, printCb, done) {
   // This is the main entry point; we're duplicating ourselves here to solve
   // a bug where the original dir might be accidentally ignored; see http://git.io/2ZiOBw
 
-  if (!firstIgnorer.isDirIgnored(fpath, fpath)) {
+  if (!firstIgnorer.isDirIgnored(fpath)) {
     job(1);
     fs.readdir(fpath, function(err, files) {
       readdirAction(files, fpath);


### PR DESCRIPTION
`.gitignore` patterns are meant to be matched against repository relative paths.

This PR changes that, but it also changes `.nakignore` patterns and command line exclusions to do the same which I'm not sure if you want or not, but it seems natural to me.
